### PR TITLE
Add support for using section pages without content as links

### DIFF
--- a/themes/ace-documentation/layouts/_default/home.sitemap.xml
+++ b/themes/ace-documentation/layouts/_default/home.sitemap.xml
@@ -8,6 +8,7 @@
         {{- $urlsToExclude = $urlsToExclude | append $productUrl -}}  
     {{- end -}}   
   {{- range (sort (where .Site.Pages "Permalink" "not in" $urlsToExclude) "Params.url" "asc") }}
+  {{ if ne .Params.IsMenuItemWithNoContent true -}}
   <url>
     <loc>{{ .Permalink }}</loc>
     {{ if not .Lastmod.IsZero -}}
@@ -19,5 +20,6 @@
     <priority>{{ site.Params.Sitemap.Priority }}</priority>
     {{- end }}
   </url>
+  {{- end }}
   {{- end }}
 </urlset>

--- a/themes/ace-documentation/layouts/partials/menu.html
+++ b/themes/ace-documentation/layouts/partials/menu.html
@@ -46,10 +46,16 @@
             {{- if true -}}
               {{ if .Page.IsSection -}} 
                 <a class="collapsable-menu-icon" data-toggle="collapse" data-target="#{{ .Page.Params.Id }}" aria-expanded="false" role="button" aria-controls="{{ .Page.Params.Id }}"></a>
-              {{ end -}}              
-                <a href="{{ .Page.RelPermalink }}" class="nav-link p-0  {{- if eq .Page.RelPermalink $.CurrentPage.RelPermalink}} active{{end -}}">                                      
-                      {{- partial "title" .Page -}}
-                </a>
+              {{ end -}}
+                {{ if .Page.Params.IsMenuItemWithNoContent -}}               
+                  <a class="nav-link p-0 {{- if eq .Page.RelPermalink $.CurrentPage.RelPermalink}} active{{end -}}" data-toggle="collapse" data-target="#{{ .Page.Params.Id }}" aria-expanded="false" role="button" aria-controls="{{ .Page.Params.Id }}">                                      
+                        {{- partial "title" .Page -}}
+                  </a>
+                {{- else }}
+                  <a href="{{ .Page.RelPermalink }}" class="nav-link p-0  {{- if eq .Page.RelPermalink $.CurrentPage.RelPermalink}} active{{end -}}">                                      
+                        {{- partial "title" .Page -}}
+                  </a>
+                {{- end -}}
               {{- else }}
                 <span>{{- partial "title" .Page -}}</span>
               {{- end -}}


### PR DESCRIPTION
This PR adds support for using `_index` section pages without content as links in the navigation menu with the same behavior same as the icon that expands a section. 
![expanding-menu-item](https://user-images.githubusercontent.com/35294201/181295886-595852e1-044a-43b0-a43d-9ebaa728b237.gif)

